### PR TITLE
Feature/modify documents copyright

### DIFF
--- a/packages/nouns-contracts/contracts/NounsArt.sol
+++ b/packages/nouns-contracts/contracts/NounsArt.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsArt.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/NounsArt.sol
 //
-// NounsArt.sol licensed under the GPL-3.0 license.
+// NounsArt.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsArt } from './interfaces/INounsArt.sol';

--- a/packages/nouns-contracts/contracts/NounsDescriptor.sol
+++ b/packages/nouns-contracts/contracts/NounsDescriptor.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsDescriptor.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/NounsDescriptor.sol
 //
-// NounsDescriptor.sol licensed under the GPL-3.0 license.
+// NounsDescriptor.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/packages/nouns-contracts/contracts/NounsDescriptorV2.sol
+++ b/packages/nouns-contracts/contracts/NounsDescriptorV2.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsDescriptorV2.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/NounsDescriptorV2.sol
 //
-// NounsDescriptorV2.sol licensed under the GPL-3.0 license.
+// NounsDescriptorV2.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/packages/nouns-contracts/contracts/NounsSeeder.sol
+++ b/packages/nouns-contracts/contracts/NounsSeeder.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsSeeder.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/NounsSeeder.sol
 //
-// NounsSeeder.sol licensed under the GPL-3.0 license.
+// NounsSeeder.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsSeeder } from './interfaces/INounsSeeder.sol';

--- a/packages/nouns-contracts/contracts/NounsToken.sol
+++ b/packages/nouns-contracts/contracts/NounsToken.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsToken.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/NounsToken.sol
 //
-// NounsToken.sol licensed under the GPL-3.0 license.
+// NounsToken.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/packages/nouns-contracts/contracts/interfaces/INounsArt.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsArt.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's INounsArt.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/interfaces/INounsArt.sol
 //
-// INounsArt.sol licensed under the GPL-3.0 license.
+// INounsArt.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { Inflate } from '../libs/Inflate.sol';

--- a/packages/nouns-contracts/contracts/interfaces/INounsDescriptor.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsDescriptor.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's INounsDescriptor.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/interfaces/INounsDescriptor.sol
 //
-// INounsDescriptor.sol licensed under the GPL-3.0 license.
+// INounsDescriptor.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsSeeder } from './INounsSeeder.sol';

--- a/packages/nouns-contracts/contracts/interfaces/INounsDescriptorMinimal.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsDescriptorMinimal.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's INounsDescriptorMinimal.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/interfaces/INounsDescriptorMinimal.sol
 //
-// INounsDescriptorMinimal.sol licensed under the GPL-3.0 license.
+// INounsDescriptorMinimal.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsSeeder } from './INounsSeeder.sol';

--- a/packages/nouns-contracts/contracts/interfaces/INounsDescriptorV2.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsDescriptorV2.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's INounsDescriptorV2.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/interfaces/INounsDescriptorV2.sol
 //
-// INounsDescriptorV2.sol licensed under the GPL-3.0 license.
+// INounsDescriptorV2.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsSeeder } from './INounsSeeder.sol';

--- a/packages/nouns-contracts/contracts/interfaces/INounsSeeder.sol
+++ b/packages/nouns-contracts/contracts/interfaces/INounsSeeder.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's INounsSeeder.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/interfaces/INounsSeeder.sol
 //
-// INounsSeeder.sol licensed under the GPL-3.0 license.
+// INounsSeeder.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { INounsDescriptorMinimal } from './INounsDescriptorMinimal.sol';

--- a/packages/nouns-contracts/contracts/test/NounsDAOImmutable.sol
+++ b/packages/nouns-contracts/contracts/test/NounsDAOImmutable.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsDAOImmutable.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/test/NounsDAOImmutable.sol
 //
-// NounsDAOImmutable.sol licensed under the MIT license.
+// NounsDAOImmutable.sol source code licensed under the MIT license.
 // With modifications by CNNouns DAO.
 //
 // Additional conditions of MIT can be found here: https://opensource.org/licenses/MIT

--- a/packages/nouns-contracts/contracts/test/NounsDAOLogicV1Harness.sol
+++ b/packages/nouns-contracts/contracts/test/NounsDAOLogicV1Harness.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsDAOLogicV1Harness.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/test/NounsDAOLogicV1Harness.sol
 //
-// NounsDAOLogicV1Harness.sol licensed under the MIT license.
+// NounsDAOLogicV1Harness.sol source code licensed under the MIT license.
 // With modifications by CNNouns DAO.
 //
 // Additional conditions of MIT can be found here: https://opensource.org/licenses/MIT

--- a/packages/nouns-contracts/contracts/test/NounsDAOLogicV2Harness.sol
+++ b/packages/nouns-contracts/contracts/test/NounsDAOLogicV2Harness.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.6;
 // This file is a modified version of nounsDAO's NounsDAOLogicV2Harness.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/test/NounsDAOLogicV2Harness.sol
 //
-// NounsDAOLogicV2Harness.sol licensed under the MIT license.
+// NounsDAOLogicV2Harness.sol source code licensed under the MIT license.
 // With modifications by CNNouns DAO.
 //
 // Additional conditions of MIT can be found here: https://opensource.org/licenses/MIT

--- a/packages/nouns-contracts/contracts/test/NounsTokenHarness.sol
+++ b/packages/nouns-contracts/contracts/test/NounsTokenHarness.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.15;
 // This file is a modified version of nounsDAO's NounsTokenHarness.sol:
 // https://github.com/nounsDAO/nouns-monorepo/blob/854b9b64770401da71503972c65c4f9eda060ba6/packages/nouns-contracts/contracts/test/NounsTokenHarness.sol
 //
-// NounsTokenHarness.sol licensed under the GPL-3.0 license.
+// NounsTokenHarness.sol source code Copyright Nouns licensed under the GPL-3.0 license.
 // With modifications by CNNouns DAO.
 
 import { NounsToken } from '../NounsToken.sol';


### PR DESCRIPTION
I've add `source code Copyright Nouns` to LICENSE comments except test/NounsDAOImmutable.sol, test/NounsDAOLogicV1Harness.sol and test/NounsDAOLogicV2Harness.sol.
I've add `source code` text to the expected files. (it follows comment style in https://github.com/CNNouns/cnnouns-monorepo/blob/develop/packages/nouns-contracts/contracts/governance/NounsDAOProxy.sol#L32).

Reason of why excepted is the licensor is not clear. It looks like come from Compound Bravo but I couldn't find any such description.
